### PR TITLE
Fix: Use null instead of false for cross_region_restore_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,8 @@ resource "azurerm_data_protection_backup_vault" "main" {
   redundancy          = var.redundancy
 
   # Cross-region restore only works with GeoRedundant storage
-  cross_region_restore_enabled = var.redundancy == "GeoRedundant" ? var.cross_region_restore_enabled : false
+  # Parameter must be completely omitted (not set to false) for LocallyRedundant/ZoneRedundant
+  cross_region_restore_enabled = var.redundancy == "GeoRedundant" ? var.cross_region_restore_enabled : null
 
   # Immutability settings - default to Unlocked for immutable backups
   immutability = var.immutability


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-29358 

### Change description

- Azure requires cross_region_restore_enabled parameter to be completely omitted (not set to false) when redundancy is LocallyRedundant or ZoneRedundant

Fixes issue discovered during CPP backup vault implementation where LocallyRedundant storage was causing Azure API errors due to the cross_region_restore_enabled parameter being explicitly set to false.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
