### PR TITLE
DTSPO-29360 Update module to be able to do role assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This module provisions a centralised Azure Backup Vault for Disaster Recovery (D
 
 ```hcl
 module "backup_vault" {
-  source = "git::https://github.com/hmcts/cpp-module-terraform-azurerm-backup-vault.git?ref=main"
+  source = "git::https://github.com/hmcts/module-terraform-azurerm-backup-vault.git?ref=main"
 
   name                = "bvault-cpp-postgresql-prd"
   resource_group_name = azurerm_resource_group.backup.name
@@ -37,6 +37,14 @@ module "backup_vault" {
   # - redundancy = "GeoRedundant"
   # - immutability = "Unlocked"
   # - cross_region_restore_enabled = true
+
+  # Grant vault identity Reader on resource groups containing PostgreSQL servers
+  role_assignments = {
+    "reader-rg-prd-svc-01" = {
+      scope                = data.azurerm_resource_group.svc.id
+      role_definition_name = "Reader"
+    }
+  }
 
   tags = {
     environment = "prd"
@@ -60,24 +68,36 @@ resource "azurerm_data_protection_backup_instance_postgresql_flexible_server" "m
 }
 ```
 
-### Required RBAC for PostgreSQL Backup
+### RBAC Role Assignments
 
-The backup vault's managed identity requires specific roles for backup and restore operations:
+The module includes a built-in `role_assignments` variable to assign roles to the vault's managed identity on any Azure resource scope. This is required for backup enrollment of PostgreSQL Flexible Servers.
 
-**For Backup:**
+**Required roles for PostgreSQL backup:**
+
+| Role | Scope | Managed By |
+|------|-------|------------|
+| `Reader` | Resource group containing the PostgreSQL server | This module (via `role_assignments`) |
+| `PostgreSQL Flexible Server Long Term Retention Backup Role` | PostgreSQL server | PostgreSQL module |
+
 ```hcl
-# Long Term Retention Backup Role on the PostgreSQL server
-resource "azurerm_role_assignment" "backup_ltr" {
-  scope                = azurerm_postgresql_flexible_server.main.id
-  role_definition_name = "PostgreSQL Flexible Server Long Term Retention Backup Role"
-  principal_id         = module.backup_vault.backup_vault_principal_id
-}
+module "backup_vault" {
+  source = "git::https://github.com/hmcts/module-terraform-azurerm-backup-vault.git?ref=main"
 
-# Reader on the resource group containing the server
-resource "azurerm_role_assignment" "backup_reader" {
-  scope                = azurerm_resource_group.main.id
-  role_definition_name = "Reader"
-  principal_id         = module.backup_vault.backup_vault_principal_id
+  name                = "bvault-cpp-postgresql-prd"
+  resource_group_name = azurerm_resource_group.backup.name
+  location            = azurerm_resource_group.backup.location
+
+  # Grant vault identity Reader on resource groups containing PostgreSQL servers
+  role_assignments = {
+    "reader-rg-dev-svc-01" = {
+      scope                = data.azurerm_resource_group.svc.id
+      role_definition_name = "Reader"
+    }
+    "reader-rg-dev-data-01" = {
+      scope                = data.azurerm_resource_group.data.id
+      role_definition_name = "Reader"
+    }
+  }
 }
 ```
 
@@ -137,6 +157,7 @@ Extended retention can be disabled via `crit4_5_enable_extended_retention = fals
 | enable_postgresql_crit4_5_policy | Create the crit4_5 backup policy | `bool` | `true` | no |
 | enable_postgresql_test_policy | Create the test backup policy | `bool` | `true` | no |
 | crit4_5_enable_extended_retention | Enable monthly/yearly extended retention | `bool` | `true` | no |
+| role_assignments | Map of role assignments for the vault's managed identity (key = name, value = {scope, role_definition_name}) | `map(object)` | `{}` | no |
 
 See [variables.tf](variables.tf) for the complete list of inputs.
 
@@ -149,6 +170,7 @@ See [variables.tf](variables.tf) for the complete list of inputs.
 | postgresql_crit4_5_policy_id | The crit4_5 policy ID for critical databases |
 | postgresql_test_policy_id | The test policy ID for testing |
 | postgresql_policy_ids | Map of policy names to IDs |
+| role_assignment_ids | Map of role assignment keys to their Azure resource IDs |
 
 ## Important Notes
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -49,6 +49,15 @@ module "backup_vault" {
   # - 12-month monthly extended retention
   # - 3-year yearly extended retention
 
+  # RBAC: Grant vault's managed identity Reader on the PostgreSQL resource group
+  # This is required for backup enrollment of PostgreSQL Flexible Servers
+  role_assignments = {
+    "reader-${azurerm_resource_group.backup.name}" = {
+      scope                = azurerm_resource_group.backup.id
+      role_definition_name = "Reader"
+    }
+  }
+
   # Tags
   namespace   = var.namespace
   application = var.application

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -28,6 +28,11 @@ output "policy_ids_map" {
   value       = module.backup_vault.postgresql_policy_ids
 }
 
+output "role_assignment_ids" {
+  description = "Map of role assignment keys to their Azure resource IDs"
+  value       = module.backup_vault.role_assignment_ids
+}
+
 output "vault_configuration" {
   description = "Summary of the vault configuration"
   value       = module.backup_vault.vault_configuration

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,21 @@ resource "azurerm_data_protection_backup_vault" "main" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# RBAC ROLE ASSIGNMENTS
+# Assigns roles to the vault's managed identity on specified resource scopes.
+# Common use case: "Reader" on resource groups containing PostgreSQL servers
+# that will be enrolled for backup.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "azurerm_role_assignment" "vault_identity" {
+  for_each = var.role_assignments
+
+  scope                = each.value.scope
+  role_definition_name = each.value.role_definition_name
+  principal_id         = azurerm_data_protection_backup_vault.main.identity[0].principal_id
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # BACKUP POLICY - CRIT4_5 (Criticality 4 and 5 Services)
 # Policy for critical services with 8-week retention per MOJ security guidance
 # Reference: https://security-guidance.service.justice.gov.uk/system-backup-standard/#retention-schedules

--- a/outputs.tf
+++ b/outputs.tf
@@ -65,6 +65,11 @@ output "postgresql_policy_ids" {
   )
 }
 
+output "role_assignment_ids" {
+  description = "Map of role assignment keys to their Azure resource IDs."
+  value       = { for k, v in azurerm_role_assignment.vault_identity : k => v.id }
+}
+
 output "vault_configuration" {
   description = "Summary of the backup vault configuration for documentation and validation purposes."
   value = {

--- a/variables.tf
+++ b/variables.tf
@@ -185,6 +185,20 @@ variable "test_retention_duration" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL VARIABLES - RBAC Role Assignments
+# Assign roles to the vault's managed identity on specified resource scopes
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "role_assignments" {
+  type = map(object({
+    scope                = string
+    role_definition_name = string
+  }))
+  description = "Map of role assignments for the backup vault's managed identity. Key is a unique descriptive name, value contains the resource scope (any Azure resource ID) and the role to assign. Requires enable_system_assigned_identity = true."
+  default     = {}
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL VARIABLES - Tags
 # ---------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-29360

### Change description

For backups to work vault identity needs two role assignments. One is reader role on the RG where PG instance lives and second is PostgreSQL Flexible Server Long Term Retention Backup Role on the instance itself.
This update is to enable us to give Reader role on Resource group's where postgres instances live.
The Long Term Retention Backup Role will be applied as part of instance enrollment.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
